### PR TITLE
Fix bug with NPE

### DIFF
--- a/src/main/groovy/com/cscinfo/platform/constraint/CascadeValidationConstraint.groovy
+++ b/src/main/groovy/com/cscinfo/platform/constraint/CascadeValidationConstraint.groovy
@@ -36,8 +36,12 @@ class CascadeValidationConstraint extends AbstractVetoingConstraint {
     }
 
     private boolean validateValue(target, value, errors, index = null) {
+        if (value == null) {
+            return false
+        }
+        
         if (!value.respondsTo('validate')) {
-            throw new NoSuchMethodException("Error validating field [${constraintPropertyName}]. Unable to apply 'cascade' constraint on [${value.class}] because the object does not have a validate() method. If the object is a command object, you may need to add the @Validateable annotation to the class definition.")
+            throw new NoSuchMethodException("Error validating field [${constraintPropertyName}]. Unable to apply 'cascade' constraint on [${value.getClass()}] because the object does not have a validate() method. If the object is a command object, you may need to add the @Validateable annotation to the class definition.")
         }
 
         if (value.validate()) {

--- a/src/test/groovy/com/cscinfo/platform/constraint/CascadeValidationConstraintSpec.groovy
+++ b/src/test/groovy/com/cscinfo/platform/constraint/CascadeValidationConstraintSpec.groovy
@@ -185,4 +185,24 @@ class CascadeValidationConstraintSpec extends Specification {
         expect:
         constraint.supports(List)
     }
+
+    def "constraint rejects null"() {
+        given:
+        constraint = new CascadeValidationConstraint(
+            owningClass: ValidateableParent,
+            propertyName: 'property',
+            constraintParameter: true)
+        expect:
+        constraint.validateWithVetoing(parent, null, errors) == false
+    }
+
+    def "constraint rejects nulls in collection"() {
+        given:
+        constraint = new CascadeValidationConstraint(
+            owningClass: ValidateableParentWithChildList,
+            propertyName: 'children',
+            constraintParameter: true)
+        expect:
+        constraint.validateWithVetoing(parent, [null], errors) == false
+    }
 }


### PR DESCRIPTION
`NullPointerException` is raised If at least one item in constrained collection is `null`.

```groovy
@Validateable
class SomeCommand {
    List<SubCommand> items
    static constraints = {
         items cascade: true
    }
}

new SomeCommand(items: [null]).validate() // NPE thrown, because `null`  does not have a `class` field
```